### PR TITLE
Fix match time parsing

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/HistoryAdapter.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/HistoryAdapter.kt
@@ -7,6 +7,7 @@ import be.buithg.etghaifgte.data.local.entity.PredictionEntity
 import be.buithg.etghaifgte.databinding.ItemHistoryPredictionBinding
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import be.buithg.etghaifgte.utils.parseUtcToLocal
 
 class HistoryAdapter(
     private val items: List<PredictionEntity>,
@@ -24,7 +25,7 @@ class HistoryAdapter(
     inner class HistoryViewHolder(private val binding: ItemHistoryPredictionBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(item: PredictionEntity) {
-            val dt = runCatching { LocalDateTime.parse(item.dateTime) }.getOrNull()
+            val dt = item.dateTime.parseUtcToLocal()
 
             binding.textTime.text = dt?.format(timeFormatter) ?: item.dateTime
             binding.textDate.text = dt?.format(dateFormatter) ?: item.dateTime

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/MatchAdapter.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/MatchAdapter.kt
@@ -9,8 +9,8 @@ import be.buithg.etghaifgte.databinding.MatchItemBinding
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import be.buithg.etghaifgte.utils.parseUtcToLocal
 
 import be.buithg.etghaifgte.domain.model.Match
 
@@ -64,7 +64,7 @@ class MatchAdapter(
     ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: Match, position: Int) {
-            val ldt = runCatching { LocalDateTime.parse(item.dateTimeGMT ?: "") }.getOrNull()
+            val ldt = item.dateTimeGMT.parseUtcToLocal()
             val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
             binding.tvTime.text = ldt?.format(timeFormatter) ?: "12:29"
 

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/PredictionsAdapter.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/PredictionsAdapter.kt
@@ -8,6 +8,7 @@ import be.buithg.etghaifgte.databinding.ItemHistoryPredictionBinding
 import be.buithg.etghaifgte.databinding.ItemPredictionBinding
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import be.buithg.etghaifgte.utils.parseUtcToLocal
 
 class PredictionsAdapter(
     private val items: List<PredictionEntity>
@@ -26,7 +27,7 @@ class PredictionsAdapter(
     ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: PredictionEntity) {
-            val dt = runCatching { LocalDateTime.parse(item.dateTime) }.getOrNull()
+            val dt = item.dateTime.parseUtcToLocal()
             
             binding.textTime.text = dt?.format(timeFormatter) ?: item.dateTime
             binding.textDate.text = dt?.format(dateFormatter) ?: item.dateTime

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchDetailFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchDetailFragment.kt
@@ -24,8 +24,8 @@ import be.buithg.etghaifgte.presentation.viewmodel.NoteViewModel
 import be.buithg.etghaifgte.domain.model.Match
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import be.buithg.etghaifgte.utils.parseUtcToLocal
 
 @AndroidEntryPoint
 class MatchDetailFragment : Fragment() {
@@ -212,7 +212,7 @@ class MatchDetailFragment : Fragment() {
         val formatterTime = DateTimeFormatter.ofPattern("HH:mm")
 
         val date = runCatching { LocalDate.parse(match.date ?: "") }.getOrNull()
-        val time = runCatching { LocalDateTime.parse(match.dateTimeGMT ?: "") }.getOrNull()
+        val time = match.dateTimeGMT.parseUtcToLocal()
 
         binding.tvDateValue.text = date?.format(formatterDate) ?: (match.date.orDash())
         binding.tvTimeValue.text = time?.format(formatterTime) ?: (match.dateTimeGMT.orDash())

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
@@ -18,6 +18,7 @@ import be.buithg.etghaifgte.presentation.viewmodel.PredictionsViewModel
 import be.buithg.etghaifgte.domain.model.Match
 import com.google.android.material.button.MaterialButton
 import java.time.LocalDateTime
+import be.buithg.etghaifgte.utils.parseUtcToLocal
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -90,7 +91,7 @@ class PredictionHistoryFragment : Fragment() {
 
     private fun isUpcoming(item: PredictionEntity): Boolean {
         if (item.upcoming == 1) return true
-        val dt = runCatching { LocalDateTime.parse(item.dateTime) }.getOrNull()
+        val dt = item.dateTime.parseUtcToLocal()
         return dt?.isAfter(LocalDateTime.now()) ?: false
     }
 

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/StatsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/StatsFragment.kt
@@ -18,6 +18,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Month
+import be.buithg.etghaifgte.utils.parseUtcToLocal
 import com.github.mikephil.charting.charts.LineChart
 import com.github.mikephil.charting.components.Legend
 import com.github.mikephil.charting.components.LegendEntry
@@ -54,7 +55,7 @@ class StatsFragment : Fragment(R.layout.fragment_stats) {
 
         fun monthAcc(y: Int, m: Int): Int {
             val monthList = list.filter {
-                runCatching { LocalDateTime.parse(it.dateTime) }.getOrNull()?.let { dt ->
+                it.dateTime.parseUtcToLocal()?.let { dt ->
                     dt.year == y && dt.monthValue == m
                 } ?: false
             }
@@ -147,7 +148,7 @@ class StatsFragment : Fragment(R.layout.fragment_stats) {
             axisRight.isEnabled = false
         }
 
-        val parsed = data.mapNotNull { runCatching { LocalDateTime.parse(it.dateTime) }.getOrNull() }
+        val parsed = data.mapNotNull { it.dateTime.parseUtcToLocal() }
         val monthsSet = parsed.map { it.monthValue }.distinct().sorted()
         val months = monthsSet.map { Month.of(it).name.take(3) }
         chart.xAxis.apply {
@@ -196,7 +197,7 @@ class StatsFragment : Fragment(R.layout.fragment_stats) {
 
         fun monthAcc(year: Int, month: Int): Float {
             val monthData = data.filter {
-                runCatching { LocalDateTime.parse(it.dateTime) }.getOrNull()?.let { dt ->
+                it.dateTime.parseUtcToLocal()?.let { dt ->
                     dt.year == year && dt.monthValue == month
                 } ?: false
             }

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
@@ -12,6 +12,7 @@ import be.buithg.etghaifgte.domain.usecase.GetCurrentMatchesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.time.LocalDate
 import java.time.LocalDateTime
+import be.buithg.etghaifgte.utils.parseUtcToLocal
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 
@@ -67,7 +68,7 @@ class PredictionsViewModel @Inject constructor(
 
     private fun isUpcoming(item: PredictionEntity): Boolean {
         if (item.upcoming == 1) return true
-        val dt = runCatching { LocalDateTime.parse(item.dateTime) }.getOrNull()
+        val dt = item.dateTime.parseUtcToLocal()
         return dt?.isAfter(LocalDateTime.now()) ?: false
     }
 
@@ -96,7 +97,7 @@ class PredictionsViewModel @Inject constructor(
         val list = _predictions.value ?: emptyList()
         val filtered = filterDate?.let { date ->
             list.filter {
-                runCatching { LocalDateTime.parse(it.dateTime).toLocalDate() }.getOrNull() == date
+                it.dateTime.parseUtcToLocal()?.toLocalDate() == date
             }
         } ?: list
 

--- a/app/src/main/java/be/buithg/etghaifgte/utils/DateUtils.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/utils/DateUtils.kt
@@ -1,0 +1,13 @@
+package be.buithg.etghaifgte.utils
+
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+fun String?.parseUtcToLocal(): LocalDateTime? {
+    if (this == null) return null
+    return runCatching { Instant.parse(this) }
+        .getOrNull()
+        ?.atZone(ZoneId.systemDefault())
+        ?.toLocalDateTime()
+}


### PR DESCRIPTION
## Summary
- add a helper to convert UTC timestamps to local time
- show local time in `MatchDetailFragment`
- use the new parser in adapters and viewmodels

## Testing
- `./gradlew --version`

------
https://chatgpt.com/codex/tasks/task_e_688818c57c1c832a8c6a359f02a375ed