### PR TITLE
Add fallback for missing country info

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/data/remote/model/Mapper.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/data/remote/model/Mapper.kt
@@ -8,6 +8,15 @@ fun EspnEvent.toMatch(league: String): Match? {
     val teamA = competition.competitors?.find { it.homeAway == "home" }
     val teamB = competition.competitors?.find { it.homeAway == "away" }
 
+    val country = competition.venue?.address?.country
+        ?: competition.venue?.address?.state?.let { "USA" }
+        ?: when (league) {
+            "nfl", "nba", "mlb", "nhl" -> "USA"
+            "eng.1" -> "England"
+            "fra.1" -> "France"
+            else -> null
+        }
+
     return Match(
         date         = competition.date?.substring(0,10),
         dateTimeGMT  = competition.date,
@@ -16,7 +25,7 @@ fun EspnEvent.toMatch(league: String): Match? {
         league       = league,
         venue        = competition.venue?.fullName,
         city         = competition.venue?.address?.city,
-        country      = competition.venue?.address?.country,
+        country      = country,
         teamA        = teamA?.team?.shortDisplayName,
         teamB        = teamB?.team?.shortDisplayName,
         scoreA       = teamA?.score?.toIntOrNull(),
@@ -46,7 +55,8 @@ data class Venue(
 
 data class VenueAddress(
     val city: String?,
-    val country: String?
+    val country: String?,
+    val state: String?
 )
 
 data class Competitor(


### PR DESCRIPTION
## Summary
- use league defaults when venue address lacks country info

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688821635264832aa96c4e9be015e460