### PR TITLE
Fix predicted count update across fragments

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/AchievementsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/AchievementsFragment.kt
@@ -8,7 +8,7 @@ import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import android.widget.Toast
 import be.buithg.etghaifgte.R
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.core.content.edit
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
@@ -29,7 +29,7 @@ import be.buithg.etghaifgte.utils.Constants.getSharedPreferences
 class AchievementsFragment : Fragment() {
 
     private lateinit var  binding: FragmentAchievementsBinding
-    private val viewModel: PredictionsViewModel by viewModels()
+    private val viewModel: PredictionsViewModel by activityViewModels()
 
     private val levels = listOf("Starter","Beginner", "Intermediate", "EXPERT")
 

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchDetailFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchDetailFragment.kt
@@ -14,7 +14,7 @@ import be.buithg.etghaifgte.databinding.DialogPredictWinnerBinding
 import be.buithg.etghaifgte.databinding.FragmentMatchDetailBinding
 import androidx.navigation.fragment.navArgs
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.cardview.widget.CardView
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.button.MaterialButton
@@ -44,7 +44,7 @@ class MatchDetailFragment : Fragment() {
     private val args: MatchDetailFragmentArgs by navArgs()
 
     private lateinit var binding: FragmentMatchDetailBinding
-    private val predictionsViewModel: PredictionsViewModel by viewModels()
+    private val predictionsViewModel: PredictionsViewModel by activityViewModels()
     private val noteViewModel: NoteViewModel by viewModels()
     private var selectedTeam: String? = null
     private lateinit var buttons: List<MaterialButton>

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
@@ -18,7 +18,7 @@ import be.buithg.etghaifgte.presentation.ui.adapters.MatchAdapter
 import be.buithg.etghaifgte.presentation.viewmodel.MatchScheduleViewModel
 import be.buithg.etghaifgte.domain.model.Match
 
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import com.google.android.material.button.MaterialButton
 import androidx.navigation.fragment.findNavController
@@ -36,7 +36,7 @@ class MatchScheduleFragment : Fragment() {
 
     private lateinit var binding: FragmentMatchScheduleBinding
     private val viewModel: MatchScheduleViewModel by viewModels()
-    private val predictionsViewModel: PredictionsViewModel by viewModels()
+    private val predictionsViewModel: PredictionsViewModel by activityViewModels()
     private lateinit var buttons: List<MaterialButton>
     private lateinit var adapter: MatchAdapter
     private var allMatches: List<Match> = emptyList()
@@ -114,7 +114,15 @@ class MatchScheduleFragment : Fragment() {
             button.setOnClickListener {
                 selectedBtn = button
                 updateSelection(button)
-                filterAndDisplay( (selectedBtn ?: binding.btnToday).id )
+
+                val date = when (button.id) {
+                    R.id.btnYesterday -> LocalDate.now().minusDays(1)
+                    R.id.btnTomorrow  -> LocalDate.now().plusDays(1)
+                    else              -> LocalDate.now()
+                }
+                predictionsViewModel.setFilterDate(date)
+
+                filterAndDisplay((selectedBtn ?: binding.btnToday).id)
             }
         }
 

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
@@ -8,7 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import be.buithg.etghaifgte.R
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import be.buithg.etghaifgte.databinding.FragmentPredictionHistoryBinding
 import androidx.core.view.isVisible
@@ -25,7 +25,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class PredictionHistoryFragment : Fragment() {
 
     private lateinit var binding: FragmentPredictionHistoryBinding
-    private val viewModel: PredictionsViewModel by viewModels()
+    private val viewModel: PredictionsViewModel by activityViewModels()
 
     private lateinit var buttons: List<MaterialButton>
     private var allPredictions: List<PredictionEntity> = emptyList()

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionsFragment.kt
@@ -7,7 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import be.buithg.etghaifgte.R
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import be.buithg.etghaifgte.databinding.FragmentPredictionsBinding
 import androidx.core.view.isVisible
@@ -19,7 +19,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class PredictionsFragment : Fragment() {
 
     private lateinit var binding: FragmentPredictionsBinding
-    private val viewModel: PredictionsViewModel by viewModels()
+    private val viewModel: PredictionsViewModel by activityViewModels()
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/StatsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/StatsFragment.kt
@@ -9,7 +9,7 @@ import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import be.buithg.etghaifgte.R
 import be.buithg.etghaifgte.databinding.FragmentStatsBinding
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import be.buithg.etghaifgte.data.local.entity.PredictionEntity
 import be.buithg.etghaifgte.presentation.viewmodel.PredictionsViewModel
@@ -31,7 +31,7 @@ class StatsFragment : Fragment(R.layout.fragment_stats) {
 
     private var _binding: FragmentStatsBinding? = null
     private val binding get() = _binding!!
-    private val viewModel: PredictionsViewModel by viewModels()
+    private val viewModel: PredictionsViewModel by activityViewModels()
 
     private fun isWin(item: PredictionEntity): Boolean {
         return when (item.wonMatches) {


### PR DESCRIPTION
## Summary
- share `PredictionsViewModel` between fragments
- update predicted count when day filter changes

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68886231b65c832aa55b2715475452f5