### PR TITLE
Fix predicted count display

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
@@ -97,7 +97,7 @@ class MatchScheduleFragment : Fragment() {
         }
 
         predictionsViewModel.predictedCount.observe(viewLifecycleOwner) {
-            binding.tvPredictedCount.text = it.toString()
+            binding.tvPredictedCount.text = it.toString().padStart(2, '0')
         }
         predictionsViewModel.wonCount.observe(viewLifecycleOwner) {
             binding.tvWonCount.text = it.toString().padStart(2, '0')

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
@@ -97,7 +97,11 @@ class PredictionsViewModel @Inject constructor(
         val list = _predictions.value ?: emptyList()
         val filtered = filterDate?.let { date ->
             list.filter {
-                it.dateTime.parseUtcToLocal()?.toLocalDate() == date
+                val dt = runCatching {
+                    it.dateTime.substring(0, 10)
+                }.getOrNull()
+                val parsed = runCatching { LocalDate.parse(dt) }.getOrNull()
+                parsed == date
             }
         } ?: list
 


### PR DESCRIPTION
## Summary
- adjust predicted count UI formatting
- fix prediction date filtering logic to use GMT date portion

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688869d33264832a847cb3e3853a563a