### PR TITLE
Fix counts updating for each date

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
@@ -97,7 +97,7 @@ class MatchScheduleFragment : Fragment() {
         }
 
         predictionsViewModel.predictedCount.observe(viewLifecycleOwner) {
-            binding.tvPredictedCount.text = it.toString()
+            binding.tvPredictedCount.text = it.toString().padStart(2, '0')
         }
         predictionsViewModel.wonCount.observe(viewLifecycleOwner) {
             binding.tvWonCount.text = it.toString().padStart(2, '0')

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
@@ -77,7 +77,8 @@ class PredictionsViewModel @Inject constructor(
             val list = getPredictionsUseCase()
             refreshUpcomingMatches(list)
             _predictions.value = getPredictionsUseCase()
-            updateCountsWithFilter()
+            val date = filterDate ?: LocalDate.now()
+            updateCountsForDate(date)
         }
     }
 
@@ -90,16 +91,16 @@ class PredictionsViewModel @Inject constructor(
 
     fun setFilterDate(date: LocalDate) {
         filterDate = date
-        updateCountsWithFilter()
+        updateCountsForDate(date)
     }
 
-    private fun updateCountsWithFilter() {
+    private fun updateCountsForDate(date: LocalDate) {
         val list = _predictions.value ?: emptyList()
-        val filtered = filterDate?.let { date ->
-            list.filter {
-                it.dateTime.parseUtcToLocal()?.toLocalDate() == date
-            }
-        } ?: list
+        val filtered = list.filter {
+            val dt = runCatching { it.dateTime.substring(0, 10) }.getOrNull()
+            val parsed = runCatching { LocalDate.parse(dt) }.getOrNull()
+            parsed == date
+        }
 
         _predictedCount.value = filtered.size
         _upcomingCount.value = filtered.count { isUpcoming(it) }


### PR DESCRIPTION
## Summary
- compute prediction counters when setting a date filter
- ensure counts refresh based on currently selected day

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688869d33264832a847cb3e3853a563a