### PR TITLE
Refactor predicted count parsing

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
@@ -53,8 +53,8 @@ class PredictionsViewModel @Inject constructor(
     fun addPrediction(entity: PredictionEntity) = viewModelScope.launch {
         addPredictionUseCase(entity)
         _predictions.value = listOf(entity) + (_predictions.value.orEmpty())
-        entity.dateTime.parseUtcToLocal()
-            ?.toLocalDate()
+        runCatching { LocalDate.parse(entity.dateTime.substring(0, 10)) }
+            .getOrNull()
             ?.let { d -> predictedCounts[d] = (predictedCounts[d] ?: 0) + 1 }
         updateCountsForDate()
     }
@@ -67,8 +67,8 @@ class PredictionsViewModel @Inject constructor(
     private fun computePredictedCounts(list: List<PredictionEntity>) {
         predictedCounts.clear()
         list.forEach { e ->
-            e.dateTime.parseUtcToLocal()
-                ?.toLocalDate()
+            runCatching { LocalDate.parse(e.dateTime.substring(0, 10)) }
+                .getOrNull()
                 ?.let { d -> predictedCounts[d] = (predictedCounts[d] ?: 0) + 1 }
         }
     }
@@ -76,7 +76,9 @@ class PredictionsViewModel @Inject constructor(
     private fun updateCountsForDate() {
         _predictedCount.value = predictedCounts[filterDate] ?: 0
         val listForDate = _predictions.value.orEmpty().filter {
-            it.dateTime.parseUtcToLocal()?.toLocalDate() == filterDate
+            val date = runCatching { LocalDate.parse(it.dateTime.substring(0, 10)) }
+                .getOrNull()
+            date == filterDate
         }
         _upcomingCount.value = listForDate.count { isUpcoming(it) }
         _wonCount.value      = listForDate.count { it.upcoming == 0 && it.wonMatches > 0 }


### PR DESCRIPTION
## Summary
- avoid timezone logic when tracking predictions by date
- parse the date string directly to update daily counts

## Testing
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68888dab4e14832a9cfeb6e7c448b69e