### PR TITLE
Refactor predicted count parsing

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
@@ -55,9 +55,14 @@ class MatchScheduleFragment : Fragment() {
     override fun onViewCreated(view: android.view.View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // 1) Инициализируем Today
-        selectedBtn = binding.btnToday
-        predictionsViewModel.setFilterDate(LocalDate.now())
+        // 1) Определяем выбранный ранее день
+        val current = predictionsViewModel.getFilterDate()
+        selectedBtn = when (current) {
+            LocalDate.now().minusDays(1) -> binding.btnYesterday
+            LocalDate.now().plusDays(1)  -> binding.btnTomorrow
+            else                         -> binding.btnToday
+        }
+        predictionsViewModel.setFilterDate(current)
 
         // 2) Подписываемся на метрики прогнозов
         predictionsViewModel.predictedCount.observe(viewLifecycleOwner) {
@@ -118,7 +123,7 @@ class MatchScheduleFragment : Fragment() {
                 filterAndDisplay(btn.id)
             }
         }
-        updateSelection(binding.btnToday)
+        updateSelection(selectedBtn!!)
     }
 
     private fun updateSelection(selected: MaterialButton) {


### PR DESCRIPTION
## Summary
- avoid timezone logic when tracking predictions by date
- parse the date string directly to update daily counts
- keep selected day when returning to schedule

## Testing
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68888dab4e14832a9cfeb6e7c448b69e