### PR TITLE
Implement daily stats flow

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/data/local/dao/PredictionDao.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/data/local/dao/PredictionDao.kt
@@ -5,6 +5,8 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import be.buithg.etghaifgte.data.local.entity.PredictionEntity
+import be.buithg.etghaifgte.domain.model.DailyStats
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface PredictionDao {
@@ -16,4 +18,14 @@ interface PredictionDao {
 
     @Query("SELECT * FROM predictions WHERE teamA = :teamA AND teamB = :teamB AND dateTime = :dateTime LIMIT 1")
     suspend fun getByMatch(teamA: String, teamB: String, dateTime: String): PredictionEntity?
+
+    @Query(
+        """
+        SELECT
+          (SELECT COUNT(*) FROM predictions WHERE matchTime BETWEEN :start AND :end) AS predicted,
+          (SELECT COUNT(*) FROM predictions WHERE matchTime BETWEEN :start AND :end AND upcomingFlag = 1) AS upcoming,
+          (SELECT COUNT(*) FROM predictions WHERE matchTime BETWEEN :start AND :end AND won = 1) AS won
+        """
+    )
+    fun getDailyStats(start: Long, end: Long): Flow<DailyStats>
 }

--- a/app/src/main/java/be/buithg/etghaifgte/data/local/database/AppDatabase.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/data/local/database/AppDatabase.kt
@@ -9,7 +9,7 @@ import be.buithg.etghaifgte.data.local.entity.NoteEntity
 
 @Database(
     entities = [PredictionEntity::class, NoteEntity::class],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/be/buithg/etghaifgte/data/local/entity/PredictionEntity.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/data/local/entity/PredictionEntity.kt
@@ -9,6 +9,7 @@ data class PredictionEntity(
     val teamA: String,
     val teamB: String,
     val dateTime: String,
+    val matchTime: Long,
     val matchType: String,
     val stadium: String,
     val city: String,
@@ -17,5 +18,7 @@ data class PredictionEntity(
     val predicted: Int,
     val corrects: Int,
     val upcoming: Int,
-    val wonMatches: Int
+    val wonMatches: Int,
+    val upcomingFlag: Boolean = false,
+    val won: Boolean = false
 )

--- a/app/src/main/java/be/buithg/etghaifgte/data/local/repository/PredictionRepositoryImpl.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/data/local/repository/PredictionRepositoryImpl.kt
@@ -2,7 +2,11 @@ package be.buithg.etghaifgte.data.local.repository
 
 import be.buithg.etghaifgte.data.local.dao.PredictionDao
 import be.buithg.etghaifgte.data.local.entity.PredictionEntity
+import be.buithg.etghaifgte.domain.model.DailyStats
 import be.buithg.etghaifgte.domain.repository.PredictionRepository
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+import java.time.ZoneOffset
 import javax.inject.Inject
 
 class PredictionRepositoryImpl @Inject constructor(
@@ -18,5 +22,11 @@ class PredictionRepositoryImpl @Inject constructor(
 
     override suspend fun getPrediction(teamA: String, teamB: String, dateTime: String): PredictionEntity? {
         return dao.getByMatch(teamA, teamB, dateTime)
+    }
+
+    override fun getDailyStats(date: LocalDate): Flow<DailyStats> {
+        val start = date.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+        val end = date.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli() - 1
+        return dao.getDailyStats(start, end)
     }
 }

--- a/app/src/main/java/be/buithg/etghaifgte/domain/model/DailyStats.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/domain/model/DailyStats.kt
@@ -1,0 +1,7 @@
+package be.buithg.etghaifgte.domain.model
+
+data class DailyStats(
+    val predicted: Int,
+    val upcoming: Int,
+    val won: Int
+)

--- a/app/src/main/java/be/buithg/etghaifgte/domain/repository/PredictionRepository.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/domain/repository/PredictionRepository.kt
@@ -1,10 +1,15 @@
 package be.buithg.etghaifgte.domain.repository
 
 import be.buithg.etghaifgte.data.local.entity.PredictionEntity
+import be.buithg.etghaifgte.domain.model.DailyStats
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
 
 interface PredictionRepository {
     suspend fun addPrediction(prediction: PredictionEntity)
     suspend fun getPredictions(): List<PredictionEntity>
 
     suspend fun getPrediction(teamA: String, teamB: String, dateTime: String): PredictionEntity?
+
+    fun getDailyStats(date: LocalDate): Flow<DailyStats>
 }

--- a/app/src/main/java/be/buithg/etghaifgte/domain/usecase/GetDailyStatsUseCase.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/domain/usecase/GetDailyStatsUseCase.kt
@@ -1,0 +1,14 @@
+package be.buithg.etghaifgte.domain.usecase
+
+import be.buithg.etghaifgte.domain.model.DailyStats
+import be.buithg.etghaifgte.domain.repository.PredictionRepository
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+import javax.inject.Inject
+
+class GetDailyStatsUseCase @Inject constructor(
+    private val repository: PredictionRepository
+) {
+    operator fun invoke(date: LocalDate): Flow<DailyStats> =
+        repository.getDailyStats(date)
+}

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchDetailFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchDetailFragment.kt
@@ -142,10 +142,21 @@ class MatchDetailFragment : Fragment() {
             val city    = parts.getOrNull(1).orEmpty()
             val country = match.country.orEmpty()
 
+            val matchTime = runCatching {
+                java.time.OffsetDateTime.parse(match.dateTimeGMT)
+                    .toInstant()
+                    .toEpochMilli()
+            }.getOrDefault(0L)
+            val wonFlag = when (won) {
+                1 -> pick == match.teamA
+                2 -> pick == match.teamB
+                else -> false
+            }
             val entity = PredictionEntity(
                 teamA      = match.teamA.orEmpty(),
                 teamB      = match.teamB.orEmpty(),
                 dateTime   = match.dateTimeGMT.orEmpty(),
+                matchTime  = matchTime,
                 matchType  = match.league.orEmpty(),
                 stadium    = stadium,
                 city       = city,
@@ -154,7 +165,9 @@ class MatchDetailFragment : Fragment() {
                 predicted  = 1,
                 corrects   = 0,
                 upcoming   = upcoming,
-                wonMatches = won
+                wonMatches = won,
+                upcomingFlag = upcoming == 1,
+                won = wonFlag
             )
             predictionsViewModel.addPrediction(entity)
             dialog.dismiss()

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
@@ -62,17 +62,15 @@ class MatchScheduleFragment : Fragment() {
             LocalDate.now().plusDays(1)  -> binding.btnTomorrow
             else                         -> binding.btnToday
         }
-        predictionsViewModel.setFilterDate(current)
+        predictionsViewModel.selectDate(current)
 
         // 2) Подписываемся на метрики прогнозов
-        predictionsViewModel.predictedCount.observe(viewLifecycleOwner) {
-            binding.tvPredictedCount.text = it.toString().padStart(2, '0')
-        }
-        predictionsViewModel.upcomingCount.observe(viewLifecycleOwner) {
-            binding.tvUpcomingCount.text = it.toString().padStart(2, '0')
-        }
-        predictionsViewModel.wonCount.observe(viewLifecycleOwner) {
-            binding.tvWonCount.text = it.toString().padStart(2, '0')
+        lifecycleScope.launchWhenStarted {
+            predictionsViewModel.dailyStats.collect { stats ->
+                binding.tvPredictedCount.text = stats.predicted.toString().padStart(2, '0')
+                binding.tvUpcomingCount.text = stats.upcoming.toString().padStart(2, '0')
+                binding.tvWonCount.text = stats.won.toString().padStart(2, '0')
+            }
         }
 
         // 3) Автозагрузка матчей при сети
@@ -119,7 +117,7 @@ class MatchScheduleFragment : Fragment() {
                     R.id.btnTomorrow  -> LocalDate.now().plusDays(1)
                     else              -> LocalDate.now()
                 }
-                predictionsViewModel.setFilterDate(date)
+                predictionsViewModel.selectDate(date)
                 filterAndDisplay(btn.id)
             }
         }


### PR DESCRIPTION
## Summary
- add `DailyStats` model and usecase
- extend `PredictionEntity` with new fields for UTC time and flags
- query database for daily stats via new DAO method
- expose daily stats in `PredictionsViewModel`
- display stats using flows in `MatchScheduleFragment`
- include new fields when saving predictions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888993728ec832abbeb019c40ca0976