### PR TITLE
Add per-day prediction counters

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
@@ -18,6 +18,7 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.material.button.MaterialButton
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.combine
 import java.time.LocalDate
 
 import be.buithg.etghaifgte.R
@@ -66,9 +67,25 @@ class MatchScheduleFragment : Fragment() {
 
         // 2) Подписываемся на метрики прогнозов
         lifecycleScope.launchWhenStarted {
+            combine(
+                predictionsViewModel.selectedDate,
+                predictionsViewModel.predYesterday,
+                predictionsViewModel.predToday,
+                predictionsViewModel.predTomorrow
+            ) { sel, y, t, tom ->
+                when (sel) {
+                    LocalDate.now().minusDays(1) -> y
+                    LocalDate.now()             -> t
+                    LocalDate.now().plusDays(1) -> tom
+                    else -> 0
+                }
+            }.collect { count ->
+                binding.tvPredictedCount.text = count.toString().padStart(2, '0')
+            }
+        }
+
+        lifecycleScope.launchWhenStarted {
             predictionsViewModel.dailyStats.collect { stats ->
-                binding.tvPredictedCount.text = stats.predicted.toString().padStart(2, '0')
-                binding.tvUpcomingCount.text = stats.upcoming.toString().padStart(2, '0')
                 binding.tvWonCount.text = stats.won.toString().padStart(2, '0')
             }
         }
@@ -156,6 +173,11 @@ class MatchScheduleFragment : Fragment() {
             }
         }
         val toShow = filtered.take(10)
+
+        // Upcoming matches count should reflect only items displayed in
+        // the RecyclerView, not the entire filtered set
+        val upcomingCount = toShow.count { !it.matchEnded }
+        binding.tvUpcomingCount.text = upcomingCount.toString().padStart(2, '0')
 
         binding.recyclerMatcher.adapter = MatchAdapter(ArrayList(toShow)) { match ->
             findNavController().navigate(

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
@@ -36,6 +36,10 @@ class PredictionsViewModel @Inject constructor(
     private val _selectedDate = MutableStateFlow(LocalDate.now())
     val selectedDate: StateFlow<LocalDate> = _selectedDate
 
+    val predYesterday = MutableStateFlow(0)
+    val predToday     = MutableStateFlow(0)
+    val predTomorrow  = MutableStateFlow(0)
+
     val dailyStats: StateFlow<DailyStats> = _selectedDate
         .flatMapLatest { getDailyStatsUseCase(it) }
         .stateIn(viewModelScope, SharingStarted.Eagerly, DailyStats(0, 0, 0))
@@ -53,6 +57,11 @@ class PredictionsViewModel @Inject constructor(
     fun addPrediction(entity: PredictionEntity) = viewModelScope.launch {
         addPredictionUseCase(entity)
         _predictions.value = listOf(entity) + (_predictions.value.orEmpty())
+        when (_selectedDate.value) {
+            LocalDate.now().minusDays(1) -> predYesterday.value++
+            LocalDate.now()             -> predToday.value++
+            LocalDate.now().plusDays(1) -> predTomorrow.value++
+        }
     }
 
     fun selectDate(date: LocalDate) {


### PR DESCRIPTION
## Summary
- track counts for yesterday, today and tomorrow in `PredictionsViewModel`
- increment counters when a prediction is added
- combine counters with the selected day in `MatchScheduleFragment`
- compute upcoming matches count from matches shown on screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888a84bc180832a8144c49ab92fb392