### PR TITLE
Rename splash fragment

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/onboarding/StartExampleSampleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/onboarding/StartExampleSampleFragment.kt
@@ -12,7 +12,7 @@ import androidx.fragment.app.Fragment
 import com.android.volley.Response
 import com.android.volley.toolbox.StringRequest
 import com.android.volley.toolbox.Volley
-import be.buithg.etghaifgte.databinding.FragmentSplashBinding
+import be.buithg.etghaifgte.databinding.FragmentStartExampleSampleBinding
 import be.buithg.etghaifgte.presentation.ui.fragments.main.HomeFragment
 import be.buithg.etghaifgte.presentation.ui.fragments.legal.PrivacyPolicyFragment
 import be.buithg.etghaifgte.utils.Constants.DEFAULT_DOMAIN_LINK
@@ -22,20 +22,21 @@ import be.buithg.etghaifgte.utils.Constants.WELCOME_KEY
 import be.buithg.etghaifgte.utils.Constants.getSharedPreferences
 import be.buithg.etghaifgte.utils.Constants.launchNewFragmentWithoutBackstack
 
-class SplashFragment : Fragment() {
+class StartExampleSampleFragment : Fragment() {
 
-    private lateinit var binding: FragmentSplashBinding
+    private lateinit var startExampleBinding: FragmentStartExampleSampleBinding
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentSplashBinding.inflate(inflater, container, false)
-        return binding.root
+        startExampleBinding = FragmentStartExampleSampleBinding.inflate(inflater, container, false)
+        return startExampleBinding.root
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        startProgressAnimation()
+        launchProgressAnimation()
+        applySplashAnimationStyle()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -45,14 +46,14 @@ class SplashFragment : Fragment() {
         handleAppInitialization()
 
     }
-    private fun startProgressAnimation() {
+    private fun launchProgressAnimation() {
         val handler = Handler(Looper.getMainLooper())
         var progress = 0f
 
         val update = object : Runnable {
             override fun run() {
                 if (progress <= 1f) {
-                    binding.progressBar.setProgress(progress)
+                    startExampleBinding.exampleProgressBar.setProgress(progress)
                     progress += 0.01f
                     handler.postDelayed(this, 16)
                 }
@@ -60,6 +61,10 @@ class SplashFragment : Fragment() {
         }
 
         handler.post(update)
+    }
+
+    private fun applySplashAnimationStyle() {
+        startExampleBinding.exampleProgressBar.setBackgroundColor(android.graphics.Color.TRANSPARENT)
     }
 
     private fun navigateToProjectFragment() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,7 +9,7 @@
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/navHostFragment"
-        android:name="be.buithg.etghaifgte.presentation.ui.fragments.onboarding.SplashFragment"
+        android:name="be.buithg.etghaifgte.presentation.ui.fragments.onboarding.StartExampleSampleFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:defaultNavHost="true"

--- a/app/src/main/res/layout/fragment_start_example_sample.xml
+++ b/app/src/main/res/layout/fragment_start_example_sample.xml
@@ -4,10 +4,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".presentation.ui.fragments.onboarding.SplashFragment">
+    tools:context=".presentation.ui.fragments.onboarding.StartExampleSampleFragment">
 
     <be.buithg.etghaifgte.presentation.ui.fragments.custom.CustomProgressBar
-        android:id="@+id/progress_bar"
+        android:id="@+id/example_progress_bar"
         android:layout_width="300dp"
         android:layout_height="60dp"
         android:indeterminateTint="@android:color/holo_red_dark"


### PR DESCRIPTION
## Summary
- rename `SplashFragment` to `StartExampleSampleFragment`
- rename the splash layout and progress bar id
- update `activity_main.xml` to reference the new splash fragment
- tweak splash fragment to call a small animation style function

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889f9237a1c832a8b5163bb075acbb5